### PR TITLE
Update generic.go

### DIFF
--- a/pkg/detectors/generic/generic.go
+++ b/pkg/detectors/generic/generic.go
@@ -20,7 +20,6 @@ func New() Scanner {
 		`[A-Z]{2,6}\-[0-9]{2,6}`, // issue tracker
 		`#[a-fA-F0-9]{6}\b`,      // hex color code
 		`\b[A-Fa-f0-9]{64}\b`,    // hex encoded hash
-		`\b[A-Fa-f0-9]{32}\b`,    // hex encoded hash
 		`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`, // http
 		`\b([/]{0,1}([\w]+[/])+[\w\.]*)\b`,                 // filepath
 		`([0-9A-F]{2}[:-]){5}([0-9A-F]{2})`,                // MAC addr
@@ -28,7 +27,6 @@ func New() Scanner {
 		`[v|\-]\d\.\d`, //version
 		`\d\.\d\.\d-`,  //version
 		`[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}`,      // IPs and OIDs
-		`\b[A-Fa-f0-9x]{6,99}\b`,                          // hex encoding
 		`[A-Fa-f0-9x]{2}:[A-Fa-f0-9x]{2}:[A-Fa-f0-9x]{2}`, // hex encoding
 		`[\w]+\([\w, ]+\)`,                                // function
 	}


### PR DESCRIPTION
Generic API keys like shown in the example below is getting excluded: api_key=9e107d9d372bb6826bd81d3542a419d6 because of following regex patterns:

\b[A-Fa-f0-9]{32}\b
\b[A-Fa-f0-9x]{6,99}\b

The base64 decoding logic is getting hit and NOT returning an error, and thus it continues thinking it is base64 decoded.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
